### PR TITLE
Bump package.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-rce-api",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
it seems something wrong with commit [9469eb16a49525176f13ab9b3f381054df2afc3b](https://github.com/instructure/canvas-rce-api/commit/9469eb16a49525176f13ab9b3f381054df2afc3b)
Although the version in `package-lock.json` is updated to 1.15.0 in this commit, yet in the code repo, it still shows 1.14.0

https://github.com/instructure/canvas-rce-api/blob/9469eb16a49525176f13ab9b3f381054df2afc3b/package-lock.json#L3

This patch update the version again, and seems good now.