### PR TITLE
Added the RCE_API_HOST environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ Configuration options are set via the following environment variables:
   be set to the host of your statsd server.
 - `STATSD_PORT`: If you would like to collect metrics with statsd, this should
   be set to the port of your statsd server.
-
+- `RCE_API_HOST`: If you need to explicitly set the host/port to which calls 
+  back to the canvas-rce-api proxy should be directed (useful if you're 
+  behind a load balancer, for example).
 ### Canvas
 
 Canvas needs to be configured with the same secrets used to encrypt and sign the

--- a/app/api/folders.js
+++ b/app/api/folders.js
@@ -57,7 +57,8 @@ function canvasResponseHandler(request, response, canvasResponse) {
   if (canvasResponse.statusCode === 200) {
     const folders = canvasResponse.body;
     const protocol = request.get("X-Forwarded-Proto") || request.protocol;
-    const baseUrl = `${protocol}://${request.get("host")}/api`;
+    const myUrl = process.env.RCE_API_HOST || request.get("host");
+    const baseUrl = `${protocol}://${myUrl}/api`;
     response.send({
       folders: transformBody(baseUrl, folders),
       bookmark: packageBookmark(request, canvasResponse.bookmark)

--- a/app/api/packageBookmark.js
+++ b/app/api/packageBookmark.js
@@ -10,7 +10,9 @@ function packageBookmark(request, bookmark) {
     const path = request.baseUrl + request.path;
     const query = Object.assign({}, request.query, { bookmark });
     const qs = querystring.stringify(query);
-    return `${request.protocol}://${request.get("Host")}${path}?${qs}`;
+    const myUrl =
+      process.env.RCE_API_HOST || request.get("host") || request.get("Host");
+    return `${request.protocol}://${myUrl}${path}?${qs}`;
   } else {
     return null;
   }


### PR DESCRIPTION
This patch is same as #5 , with `package-lock.json` excluded. And make it easy to be merged into master.